### PR TITLE
Fix file search paths for Bazel

### DIFF
--- a/crates/tauri-utils/Cargo.toml
+++ b/crates/tauri-utils/Cargo.toml
@@ -40,7 +40,7 @@ json-patch = "3.0"
 glob = "0.3.1"
 urlpattern = "0.3"
 regex = "1"
-walkdir = { version = "2", optional = true }
+walkdir = "2"
 memchr = "2"
 semver = "1"
 infer = "0.19"
@@ -73,5 +73,5 @@ isolation = ["aes-gcm", "getrandom", "serialize-to-javascript"]
 process-relaunch-dangerous-allow-symlink-macos = []
 config-json5 = ["json5"]
 config-toml = []
-resources = ["walkdir"]
+resources = []
 html-manipulation = ["dep:html5ever", "dep:kuchiki"]

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -342,7 +342,14 @@ fn main() {
     }
   }
 
-  let tauri_global_scripts = PathBuf::from("./scripts/bundle.global.js")
+  // NOTE(paris): When building Tauri apps, we update `rules_rust()` to not change the working 
+  // directory to the Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox 
+  // root. This is important b/c many of our build tools (i.e. workspace-env) expect to be run from 
+  // the sandbox root.
+  //
+  // This means that bundle.global.js may not be available in the current working dir. So we instead
+  // search for it in the current directory or any child directory.
+  let tauri_global_scripts = PathBuf::from(tauri_utils::config::parse::find_file("bundle.global.js", &std::env::current_dir().unwrap()))
     .canonicalize()
     .expect("failed to canonicalize tauri global API script path");
   tauri_utils::plugin::define_global_api_script_path(&tauri_global_scripts);


### PR DESCRIPTION
### What
When building Tauri apps, we update `rules_rust()` to not change the working directory to the Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox root. This is important b/c many of our build tools (i.e. workspace-env) expect to be run from the sandbox root.

But when doing that, we get errors from several places which try to load files assuming they are in the working directory. But they are likely not, instead they are in a child dir of the working directory within the sandbox. So here we update to traverse down the filesystem looking for the requested file.

### Testing
Before this change we would error, now we can build.