### PR TITLE
Fix the iOS API path and copied .tauri directory

### DIFF
--- a/crates/tauri-plugin/src/build/mobile.rs
+++ b/crates/tauri-plugin/src/build/mobile.rs
@@ -98,8 +98,15 @@ pub(crate) fn setup(
           .unwrap();
         let tauri_library_path = std::env::var("DEP_TAURI_IOS_LIBRARY_PATH")
             .expect("missing `DEP_TAURI_IOS_LIBRARY_PATH` environment variable. Make sure `tauri` is a dependency of the plugin.");
-
-        let tauri_dep_path = path.parent().unwrap().join(".tauri");
+        
+        // NOTE(paris): When building Tauri apps, we update `rules_rust()` to not change the working 
+        // directory to the Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox 
+        // root. This is important b/c many of our build tools (i.e. workspace-env) expect to be run from 
+        // the sandbox root.
+        // 
+        // This means that here we need to copy files not just into .tauri, but into the root of the 
+        // plugin.
+        let tauri_dep_path = manifest_dir.join(".tauri");
         create_dir_all(&tauri_dep_path).context("failed to create .tauri directory")?;
         copy_folder(
           Path::new(&tauri_library_path),


### PR DESCRIPTION
### What
Fix two errors when building Tauri apps with Bazel - thank you to Lucas for the help here!!

### Testing
With the fix to `crates/tauri/build.rs`, we no longer get:
```
tauri_plugin: failed to copy tauri-api to the plugin project: IO error for operation on /private/var/tmp/_bazel_<name>/<id>/sandbox/darwin-sandbox/30354/execroot/_main/bazel-out/ios_arm64-fastbuild/bin/external/tauri-deps__tauri-2.8.2/_bs.cargo_runfiles/tauri-deps__tauri-2.8.2/mobile/ios-api: No such file or directory (os error 2): No such file or directory (os error 2)
```

After that, with the fix to `crates/tauri-plugin/src/build/mobile.rs`, we longer get:
```
....tauri/tauri-api' cannot be accessed (Error Domain=NSCocoaErrorDomain Code=260 "The folder “tauri-api” doesn’t exist." UserInfo={NSUserStringVariant=(
```