### PR TITLE
[nae] Update IOS_LIBRARY_PATH to be relative from BAZEL_OUTPUT_BASE

### DIFF
--- a/crates/tauri-plugin/src/build/mobile.rs
+++ b/crates/tauri-plugin/src/build/mobile.rs
@@ -96,12 +96,15 @@ pub(crate) fn setup(
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
           .map(PathBuf::from)
           .unwrap();
+        let bazel_output_path = std::env::var("BAZEL_OUTPUT_BASE")
+          .map(PathBuf::from)
+          .unwrap();
         let tauri_library_path = std::env::var("DEP_TAURI_IOS_LIBRARY_PATH")
-            .expect("missing `DEP_TAURI_IOS_LIBRARY_PATH` environment variable. Make sure `tauri` is a dependency of the plugin.");
-        
-        // NOTE(paris): When building Tauri apps, we update `rules_rust()` to not change the working 
-        // directory to the Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox 
-        // root. This is important b/c many of our build tools (i.e. workspace-env) expect to be run from 
+          .expect("missing `DEP_TAURI_IOS_LIBRARY_PATH` environment variable. Make sure `tauri` is a dependency of the plugin.");
+
+        // NOTE(paris): When building Tauri apps, we update `rules_rust()` to not change the working
+        // directory to the Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox
+        // root. This is important b/c many of our build tools (i.e. workspace-env) expect to be run from
         // the sandbox root.
         // 
         // This means that here we need to copy files not just into .tauri, but into the root of the 
@@ -109,7 +112,7 @@ pub(crate) fn setup(
         let tauri_dep_path = manifest_dir.join(".tauri");
         create_dir_all(&tauri_dep_path).context("failed to create .tauri directory")?;
         copy_folder(
-          Path::new(&tauri_library_path),
+          &bazel_output_path.join(tauri_library_path),
           &tauri_dep_path.join("tauri-api"),
           &[".build", "Package.resolved", "Tests"],
         )

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -362,7 +362,14 @@ fn main() {
       };
 
       tauri_utils::build::link_apple_library("Tauri", &lib_path_canon);
-      println!("cargo:ios_library_path={}", lib_path_canon.display());
+
+      // We want the relative paths to be the values that end up in `bazel-out/ios_arm64-fastbuild/bin/external/tauri-deps__tauri-2.8.2/_bs.depenv`,
+      // this prevents remote caches from providing absolute paths that don't exist on local machines.
+      let bazel_output_path = std::env::var("BAZEL_OUTPUT_BASE")
+          .map(PathBuf::from)
+          .unwrap();
+      let relative_lib_path = lib_path_canon.strip_prefix(&bazel_output_path).expect("failed to get relative path for iOS library");
+      println!("cargo:ios_library_path={}", relative_lib_path.display());
     }
   }
 


### PR DESCRIPTION
# Context

Dependent on https://github.com/8thwall/code8/pull/3676 to use `BAZEL_OUTPUT_BASE` to get the base path to use 
with local bazel builds.

This PR stores the relative path of the IOS_LIBRARY_PATH from the `tauri_plugin` build script. We still get the canonicalized version of the path, but strip the `BAZEL_OUTPUT_BASE` since we don't want absolute paths to be in the `.depenv` bazel outputs for the `cargo_build_script`.

When the path is read by the `plugin.rs` at runtime, we prepend the `BAZEL_OUTPUT_BASE` to make sure we get the correct path for the workspace that is currently being used to run the rule.

# Test

I'm able to build the tauri shell with these changes and can see that the expected relative path is in the bazel output at:
`/private/var/tmp/_bazel_lucas/38594d40c43ab903d136e895c662c8a3/execroot/_main/bazel-out/ios_arm64-fastbuild/bin/external/tauri-deps__tauri-2.8.2/_bs.depenv`

I ran:
```
bazel clean

bazel build //c8/html-shell-tauri:main --platforms=//bzl:ios_arm64
```

```
DEP_TAURI_IOS_LIBRARY_PATH=external/tauri-deps__tauri-2.8.2/mobile/ios-api
```