### PR TITLE
[nae][tauri] Use relative paths to get global scripts

### DIFF
--- a/crates/tauri-utils/src/plugin.rs
+++ b/crates/tauri-utils/src/plugin.rs
@@ -9,7 +9,7 @@ pub use build::*;
 #[cfg(feature = "build")]
 mod build {
   use std::{
-    env::vars_os,
+    env::{vars_os, var},
     fs,
     path::{Path, PathBuf},
   };
@@ -20,9 +20,15 @@ mod build {
 
   /// Defines the path to the global API script using Cargo instructions.
   pub fn define_global_api_script_path(path: &Path) {
+    let resolved_path = if path.is_relative() {
+      PathBuf::from(var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set")).join(path)
+    } else {
+      path.to_path_buf()
+    };
+
     println!(
       "cargo:{GLOBAL_API_SCRIPT_PATH_KEY}={}",
-      path
+      resolved_path
         .canonicalize()
         .expect("failed to canonicalize global API script path")
         .display()


### PR DESCRIPTION
# Context

As part of the effort to get Tauri Plugins to work universally, we'll need to support passing the plugin's global scripts as relative paths.
NOTE: This was not an issue with `tauri-plugin-native-app-export` because it did not contain a JS file mean for Rust to JS interopability.

`tauri-plugin-cors-fetch` has a bazel output named `.depenv` that contains a `DEP_TAURI_PLUGIN_CORS_FETCH_GLOBAL_API_SCRIPT_PATH` environment variable that will be parsed in a follow up build subcommand.

We want to store paths relative to the `BAZEL_OUTPUT_BASE`, so the paths can be used between sandboxes and different machines.

# Test

With many local changes to enable `tauri-plugin-cors-fetch` in a [TEST PR](https://github.com/8thwall/code8/pull/3742), I was able to run `apps/client/nae/loc8-royale/ios/build-install.sh` to create an iOS app with the expected `.depenv` paths.

BEFORE:
`DEP_TAURI_PLUGIN_CORS_FETCH_GLOBAL_API_SCRIPT_PATH=/private/var/tmp/_bazel_lucas/38594d40c43ab903d136e895c662c8a3/sandbox/darwin-sandbox/157140/execroot/_main/external/tauri-deps__tauri-plugin-cors-fetch-4.1.0/api-iife.js`

After:
`DEP_TAURI_PLUGIN_CORS_FETCH_GLOBAL_API_SCRIPT_PATH=external/tauri-deps__tauri-plugin-cors-fetch-4.1.0/api-iife.js`