### PR TITLE
[nae][tauri] Use relative paths to get permission files

### DIFF
--- a/crates/tauri-plugin/src/build/mod.rs
+++ b/crates/tauri-plugin/src/build/mod.rs
@@ -116,8 +116,16 @@ impl<'a> Builder<'a> {
     }
 
     println!("cargo:rerun-if-changed=permissions");
+
+    // NOTE(lreyna): When working with Bazel, our plugin permissions files will not be in the PWD directory.
+    // The path looks something like:
+    // `external/tauri-deps__tauri-plugin-cors-fetch-4.1.0/_bs-.runfiles/tauri-deps__tauri-plugin-cors-fetch-4.1.0/permissions`
+    let cargo_manifest_dir = PathBuf::from(build_var("CARGO_MANIFEST_DIR")?);
+    let permissions_pattern = cargo_manifest_dir.join("permissions").join("**/*.*");
+    let permissions_pattern_str = permissions_pattern.to_str().unwrap().to_string();
+
     let permissions =
-      acl::build::define_permissions("./permissions/**/*.*", &name, &out_dir, |_| true)?;
+      acl::build::define_permissions(&permissions_pattern_str, &name, &out_dir, |_| true)?;
 
     if permissions.is_empty() {
       let _ = std::fs::remove_file(format!(


### PR DESCRIPTION
# Context

Similar to a previous [PR](https://github.com/8thwall/tauri/pull/5), we want to use relative paths to get the permissions files from Tauri plugins.

The Tauri plugin build scripts will output files named `tauri-plugin-{}-permission-files`, similar to `.depenv` paths will be stored in this file and they should be relative, so follow up subcommands can reference the correct paths.

This PR also updates the search paths for permisions files since the `permissions` directory not going to exist in the PWD.

# Test

With many local changes to enable `tauri-plugin-cors-fetch` in a [TEST PR](https://github.com/8thwall/code8/pull/3742), I was able to run `apps/client/nae/loc8-royale/ios/build-install.sh` to create an iOS app with the expected `permission-files` paths.

**Before**
```
[
"/private/var/tmp/_bazel_lucas/38594d40c43ab903d136e895c662c8a3/sandbox/darwin-sandbox/157140/execroot/_main/external/tauri-deps__tauri-plugin-cors-fetch-4.1.0/permissions/autogenerated/commands/cancel_cors_request.toml",
"/private/var/tmp/_bazel_lucas/38594d40c43ab903d136e895c662c8a3/sandbox/darwin-sandbox/157140/execroot/_main/external/tauri-deps__tauri-plugin-cors-fetch-4.1.0/permissions/autogenerated/commands/cors_request.toml",
"/private/var/tmp/_bazel_lucas/38594d40c43ab903d136e895c662c8a3/sandbox/darwin-sandbox/157140/execroot/_main/external/tauri-deps__tauri-plugin-cors-fetch-4.1.0/permissions/default.toml"
]
```

**After**
```
[
"external/tauri-deps__tauri-plugin-cors-fetch-4.1.0/permissions/autogenerated/commands/cancel_cors_request.toml",
"external/tauri-deps__tauri-plugin-cors-fetch-4.1.0/permissions/autogenerated/commands/cors_request.toml",
"external/tauri-deps__tauri-plugin-cors-fetch-4.1.0/permissions/default.toml"
]
```