### PR TITLE
[nae][tauri] Workaround for referenced_by in ResolveCommand

### DIFF
--- a/crates/tauri-utils/src/acl/resolved.rs
+++ b/crates/tauri-utils/src/acl/resolved.rs
@@ -35,8 +35,13 @@ pub struct ResolvedCommand {
   /// The execution context of this command.
   pub context: ExecutionContext,
   /// The capability/permission that referenced this command.
-  #[cfg(debug_assertions)]
-  pub referenced_by: ResolvedCommandReference,
+  // 
+  // TODO(lreyna): Figure out why there's a potential mismatch with debug_assertions between build steps
+  // Logging for `debug_assertions` in `--config=debug` shows us that it's not, but the struct definition
+  // was compiled as if it was.
+  //
+  // #[cfg(debug_assertions)]
+  // pub referenced_by: ResolvedCommandReference,
   /// The list of window label patterns that was resolved for this command.
   pub windows: Vec<glob::Pattern>,
   /// The list of webview label patterns that was resolved for this command.
@@ -233,11 +238,11 @@ fn resolve_command(
 
     resolved_list.push(ResolvedCommand {
       context,
-      #[cfg(debug_assertions)]
-      referenced_by: ResolvedCommandReference {
-        capability: capability.identifier.clone(),
-        permission: referenced_by_permission_identifier.clone(),
-      },
+      // #[cfg(debug_assertions)]
+      // referenced_by: ResolvedCommandReference {
+      //   capability: capability.identifier.clone(),
+      //   permission: referenced_by_permission_identifier.clone(),
+      // },
       windows: parse_glob_patterns(capability.windows.clone())?,
       webviews: parse_glob_patterns(capability.webviews.clone())?,
       scope_id,

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -240,7 +240,9 @@ impl RuntimeAuthority {
         .map(|r| {
           format!(
             "capability: {}, permission: {}",
-            r.referenced_by.capability, r.referenced_by.permission
+            "<<capability>>", // TODO(lreyna): Fix issue with `referenced_by` in debug mode
+            "<<permission>>"
+            // r.referenced_by.capability, r.referenced_by.permission
           )
         })
         .collect::<Vec<_>>()
@@ -421,8 +423,10 @@ impl RuntimeAuthority {
                 };
                 format!(
                   "- context: {context}, referenced by: capability: {}, permission: {}",
-                  resolved.referenced_by.capability,
-                  resolved.referenced_by.permission
+                  "<<capability>>", // TODO(lreyna): Fix issue with `referenced_by` in debug mode
+                  "<<permission>>"
+                  // resolved.referenced_by.capability,
+                  // resolved.referenced_by.permission
                 )
               })
               .collect::<Vec<_>>()


### PR DESCRIPTION
# Context

Constantly getting the following when building the tauri html-shell (except when building with `--config=release`):

```
error[E0063]: missing field `referenced_by` in initializer of `ResolvedCommand`
  --> c8/html-shell-tauri/src/lib.rs:72:14
   |
72 |         .run(tauri::generate_context!())
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `referenced_by`
   |
   = note: this error originates in the macro `tauri::generate_context` (in Nightly builds, run with -Z macro-backtrace for more info)
```

There are guards for a struct property in `ResolveCommand`, for some reason our build system seems to be having a mismatch somewhere, but I cannot find where things are going wrong. The error seems to imply that `referenced_by` should be included when the struct is initialized, but it's being initialized without `debug_assertions`.

I tried the following:
- Added `-C debug-assertions=no` / `-C debug-assertions=yes` to every build target when building the shell to try to unify everything, this did not work.
- Added `[profile.dev]` with `debug_assertsions = false` / `true` in `Cargo.toml`, and rebuilt the shell. This also did not work.
- Different combinations of feature flags in `Cargo.toml`, but this also didn't work
- Added many logs in different build steps, which all seemed to imply that `debug_assertions` was false when building with `--config=fastbuild`
- Moved the `debug_assertions` scopes in case there was some weirdness there, did not work.

To keep progress, this PR just comments out some debug logs associated with `referenced_by`
- Left a TODO in case we need to revisit this.

# Test

Loc8 Royale can build with `tauri-plugin-cors-fetch` in `debug`, `fastbuild`, and `release` mode:
`apps/client/nae/loc8-royale/ios/build-install.sh`