### PR TITLE
[nae][tauri] Use CARGO_MANIFEST_DIR for capabilities path

### DIFF
--- a/crates/tauri-build/src/acl.rs
+++ b/crates/tauri-build/src/acl.rs
@@ -425,7 +425,11 @@ pub fn build(out_dir: &Path, target: Target, attributes: &Attributes) -> super::
     tauri_utils::acl::build::parse_capabilities(pattern)?
   } else {
     println!("cargo:rerun-if-changed=capabilities");
-    tauri_utils::acl::build::parse_capabilities("./capabilities/**/*")?
+
+    // NOTE(lreyna): When working with Bazel, our tauri shell capabilities will not be in the PWD directory.
+    let cargo_manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR").unwrap();
+    let capability_path_pattern = format!("{}/capabilities/**/*", cargo_manifest_dir.to_string_lossy());
+    tauri_utils::acl::build::parse_capabilities(&capability_path_pattern)?
   };
   validate_capabilities(&acl_manifests, &capabilities)?;
 


### PR DESCRIPTION
# Context

Similar to a previous [PR](https://github.com/8thwall/tauri/pull/3/files), we should use `CARGO_MANIFEST_DIR` to reference some files in our bazel runfiles directory.

The capabilities path will find the `c8/html-shell-tauri/capabilities/default.json` that we outline as a data dependency when building the Tauri shell.

# Test

Can build and run `loc8-royale` with `cors-fetch`:
`apps/client/nae/loc8-royale/ios/build-install.sh`