### PR TITLE
[nae][tauri] Apply referenced_by workaround to other places

### DIFF
--- a/crates/tauri-utils/src/acl/resolved.rs
+++ b/crates/tauri-utils/src/acl/resolved.rs
@@ -39,9 +39,10 @@ pub struct ResolvedCommand {
   // TODO(lreyna): Figure out why there's a potential mismatch with debug_assertions between build steps
   // Logging for `debug_assertions` in `--config=debug` shows us that it's not, but the struct definition
   // was compiled as if it was.
+  // This issue is specifically happening for our ios builds
   //
-  // #[cfg(debug_assertions)]
-  // pub referenced_by: ResolvedCommandReference,
+  #[cfg(all(debug_assertions, not(target_os = "ios")))]
+  pub referenced_by: ResolvedCommandReference,
   /// The list of window label patterns that was resolved for this command.
   pub windows: Vec<glob::Pattern>,
   /// The list of webview label patterns that was resolved for this command.

--- a/crates/tauri-utils/src/acl/resolved.rs
+++ b/crates/tauri-utils/src/acl/resolved.rs
@@ -39,10 +39,9 @@ pub struct ResolvedCommand {
   // TODO(lreyna): Figure out why there's a potential mismatch with debug_assertions between build steps
   // Logging for `debug_assertions` in `--config=debug` shows us that it's not, but the struct definition
   // was compiled as if it was.
-  // This issue is specifically happening for our ios builds
   //
-  #[cfg(all(debug_assertions, not(target_os = "ios")))]
-  pub referenced_by: ResolvedCommandReference,
+  // #[cfg(debug_assertions)]
+  // pub referenced_by: ResolvedCommandReference,
   /// The list of window label patterns that was resolved for this command.
   pub windows: Vec<glob::Pattern>,
   /// The list of webview label patterns that was resolved for this command.
@@ -469,9 +468,6 @@ mod build {
 
   impl ToTokens for ResolvedCommand {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-      #[cfg(debug_assertions)]
-      let referenced_by = &self.referenced_by;
-
       let context = &self.context;
 
       let windows = vec_lit(&self.windows, |window| {
@@ -484,19 +480,21 @@ mod build {
       });
       let scope_id = opt_lit(self.scope_id.as_ref());
 
-      #[cfg(debug_assertions)]
-      {
-        literal_struct!(
-          tokens,
-          ::tauri::utils::acl::resolved::ResolvedCommand,
-          context,
-          referenced_by,
-          windows,
-          webviews,
-          scope_id
-        )
-      }
-      #[cfg(not(debug_assertions))]
+      // #[cfg(debug_assertions)]
+      // {
+      //   let referenced_by = &self.referenced_by;
+
+      //   literal_struct!(
+      //     tokens,
+      //     ::tauri::utils::acl::resolved::ResolvedCommand,
+      //     context,
+      //     referenced_by,
+      //     windows,
+      //     webviews,
+      //     scope_id
+      //   )
+      // }
+      // #[cfg(not(debug_assertions))]
       literal_struct!(
         tokens,
         ::tauri::utils::acl::resolved::ResolvedCommand,

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -240,7 +240,8 @@ impl RuntimeAuthority {
         .map(|r| {
           format!(
             "capability: {}, permission: {}",
-            "<<capability>>", "<<permission>>" // TODO(lreyna): Fix issue with `referenced_by` in debug mode
+            "<<capability>>", // TODO(lreyna): Fix issue with `referenced_by` in debug mode
+            "<<permission>>"
             // r.referenced_by.capability, r.referenced_by.permission
           )
         })

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -240,9 +240,11 @@ impl RuntimeAuthority {
         .map(|r| {
           format!(
             "capability: {}, permission: {}",
-            "<<capability>>", // TODO(lreyna): Fix issue with `referenced_by` in debug mode
-            "<<permission>>"
-            // r.referenced_by.capability, r.referenced_by.permission
+            #[cfg(target_os = "ios")]
+            "<<capability>>", "<<permission>>" // TODO(lreyna): Fix issue with `referenced_by` in debug mode for iOS
+
+            #[cfg(not(target_os = "ios"))]
+            r.referenced_by.capability, r.referenced_by.permission
           )
         })
         .collect::<Vec<_>>()
@@ -423,10 +425,11 @@ impl RuntimeAuthority {
                 };
                 format!(
                   "- context: {context}, referenced by: capability: {}, permission: {}",
-                  "<<capability>>", // TODO(lreyna): Fix issue with `referenced_by` in debug mode
-                  "<<permission>>"
-                  // resolved.referenced_by.capability,
-                  // resolved.referenced_by.permission
+                  #[cfg(target_os = "ios")]
+                  "<<capability>>", "<<permission>>" // TODO(lreyna): Fix issue with `referenced_by` in debug mode for iOS
+
+                  #[cfg(not(target_os = "ios"))]
+                  resolved.referenced_by.capability, resolved.referenced_by.permission
                 )
               })
               .collect::<Vec<_>>()

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -240,11 +240,8 @@ impl RuntimeAuthority {
         .map(|r| {
           format!(
             "capability: {}, permission: {}",
-            #[cfg(target_os = "ios")]
-            "<<capability>>", "<<permission>>" // TODO(lreyna): Fix issue with `referenced_by` in debug mode for iOS
-
-            #[cfg(not(target_os = "ios"))]
-            r.referenced_by.capability, r.referenced_by.permission
+            "<<capability>>", "<<permission>>" // TODO(lreyna): Fix issue with `referenced_by` in debug mode
+            // r.referenced_by.capability, r.referenced_by.permission
           )
         })
         .collect::<Vec<_>>()
@@ -425,11 +422,10 @@ impl RuntimeAuthority {
                 };
                 format!(
                   "- context: {context}, referenced by: capability: {}, permission: {}",
-                  #[cfg(target_os = "ios")]
-                  "<<capability>>", "<<permission>>" // TODO(lreyna): Fix issue with `referenced_by` in debug mode for iOS
-
-                  #[cfg(not(target_os = "ios"))]
-                  resolved.referenced_by.capability, resolved.referenced_by.permission
+                  "<<capability>>", // TODO(lreyna): Fix issue with `referenced_by` in debug mode
+                  "<<permission>>"
+                  // resolved.referenced_by.capability,
+                  // resolved.referenced_by.permission
                 )
               })
               .collect::<Vec<_>>()


### PR DESCRIPTION
# Context

Nightly CI failed with:
```
17:11:08 [104,547 / 104,646] Compiling Rust rlib tauri_utils v2.7.0 (340 files); 23s disk-cache, remote-cache, darwin-sandbox ... (14 actions running)
17:11:09 [104,556 / 104,646] Compiling Rust rlib tauri_utils v2.7.0 (340 files); 24s disk-cache, remote-cache, darwin-sandbox ... (9 actions running)
17:11:10 [104,560 / 104,646] Compiling Rust rlib tauri_utils v2.7.0 (340 files); 21s disk-cache, remote-cache, darwin-sandbox ... (9 actions, 8 running)
17:11:11 [104,560 / 104,646] Compiling Rust rlib tauri_utils v2.7.0 (340 files); 23s disk-cache, remote-cache, darwin-sandbox ... (9 actions running)
17:11:12 [104,561 / 104,646] Compiling Rust rlib tauri_utils v2.7.0 (340 files) [for tool]; 15s disk-cache, remote-cache, darwin-sandbox ... (9 actions, 8 running)
17:11:12 ERROR: /private/var/tmp/_bazel_jenkins/c61868919da5929a7455aa535ebdae56/external/tauri-deps__tauri-utils-2.7.0/BUILD.bazel:16:13: Compiling Rust rlib tauri_utils v2.7.0 (340 files) failed: (Exit 1): process_wrapper failed: error executing Rustc command (from target @@tauri-deps__tauri-utils-2.7.0//:tauri_utils) bazel-out/darwin_arm64-opt-exec-ST-0465588ec812/bin/external/rules_rust/util/process_wrapper/process_wrapper --arg-file ... (remaining 252 arguments skipped)
17:11:12 
17:11:12 Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
17:11:12 error[E0609]: no field `referenced_by` on type `&resolved::ResolvedCommand`
17:11:12    --> external/tauri-deps__tauri-utils-2.7.0/src/acl/resolved.rs:472:33
17:11:12     |
17:11:12 472 |       let referenced_by = &self.referenced_by;
17:11:12     |                                 ^^^^^^^^^^^^^ unknown field
17:11:12     |
17:11:12     = note: available fields are: `context`, `windows`, `webviews`, `scope_id`
17:11:12 
17:11:12 error: aborting due to 1 previous error
17:11:12 
17:11:12 For more information about this error, try `rustc --explain E0609`.
17:11:13 INFO: Elapsed time: 214.608s, Critical Path: 39.14s
17:11:13 INFO: 1598 processes: 95 disk cache hit, 1300 internal, 203 darwin-sandbox.
17:11:13 ERROR: Build did NOT complete successfully
17:11:13 Build step 'Execute shell' marked build as failure
17:11:14 Sending e-mails to: tony@8thwall.com datchu@nianticspatial.com cbartschat@nianticspatial.com lynndang@nianticspatial.com yuhsianghuang@nianticspatial.com paris@nianticspatial.com lucas@8thwall.com
17:11:16 Finished: FAILURE
```

It turns out that building for osx tries to compile more logic than iOS that had an issue with `referenced_by`.

NOTE: I reverted the `referenced_by` workaround, but things still failed to build for osx. Originally, I had wanted to conditionally compile by doing `#[cfg(all(debug_assertions, not(target_os = "ios")))]`, but the issue is not iOS specific.

# Test

Can compile targets with both osx and iOS

`bazel build //c8/html-shell-tauri:main`

`bazel build //c8/html-shell-tauri:main --platforms=//bzl:ios_arm64`