### PR TITLE
[nae] Strip canonical path stored in permission-files

### DIFF
--- a/crates/tauri-utils/src/acl/build.rs
+++ b/crates/tauri-utils/src/acl/build.rs
@@ -85,6 +85,7 @@ pub fn define_permissions<F: Fn(&Path) -> bool>(
 ) -> Result<Vec<PermissionFile>, Error> {
   let pwd = env::var("PWD").expect("PWD not set");
   let bazel_output_base = env::var("BAZEL_OUTPUT_BASE").expect("BAZEL_OUTPUT_BASE not set");
+  let bazel_workspace = env::var("BAZEL_WORKSPACE").expect("BAZEL_WORKSPACE not set");
 
   let permission_files = glob::glob(pattern)?
     .flatten()
@@ -96,6 +97,9 @@ pub fn define_permissions<F: Fn(&Path) -> bool>(
         Some(PathBuf::from(stripped.trim_start_matches('/')))
       } else if let Some(stripped) = canonical_str.strip_prefix(&bazel_output_base) {
         Some(PathBuf::from(stripped.trim_start_matches('/')))
+      } else if let Some(stripped) = canonical_str.strip_prefix(&bazel_workspace) {
+        // Strip the workspace prefix and add the execroot path, this is complementary to the change made in https://github.com/8thwall/tauri/pull/11
+        Some(PathBuf::from("execroot/_main").join(stripped.trim_start_matches('/')))
       } else {
         Some(canonical)
       }


### PR DESCRIPTION
# Context

Noticed that the remote cache was storing an absolute path in the `${plugin-name}-permission-files` file.
This is due to the location of the `${permission}.toml` used in non-external tauri plugin sources.

Similar to #11 , strip the absolute path. (Add the execution root subpath, since the paths are read from the bazel output base).

This wasn't noticed in testing before since the absolute paths work on your local system.

# Test

Cleaned all build output for sanity.

Builds works again and `${plugin-name}-permission-files` contain relative paths for non-external tauri plugins.